### PR TITLE
merge 1.2.1 into master

### DIFF
--- a/.github/workflows/aunit_tests.yml
+++ b/.github/workflows/aunit_tests.yml
@@ -24,6 +24,7 @@ jobs:
         git clone https://github.com/bxparks/AceSorting
         git clone https://github.com/bxparks/AceTime
         git clone https://github.com/bxparks/AceWire
+        git clone https://github.com/hsaturn/EspMock
 
     - name: Verify examples
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 * Unreleased
+    * Fix incorrect reference to
+     `LocalDate::secondsToCurrentEpochFromUnixEpoch64` instead of
+     `Epoch::secondsToCurrentEpochFromUnixEpoch64`.
 * v1.2.0 (2022-11-04)
     * Replace `LocalDate::kEpochYear` with `HardwareDateTime::kBaseYear`
       since AceTime current epoch is no longer a constant and AceTime no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
     * Fix incorrect reference to
      `LocalDate::secondsToCurrentEpochFromUnixEpoch64` instead of
      `Epoch::secondsToCurrentEpochFromUnixEpoch64`.
+    * Enable GitHub Actions for ESP8266 examples (HelloEspSntpClock,
+      HelloNtpClock, HelloNtpClockLazy) to catch compiler errors.
+        * Depends on EpoxyDuino v1.4.0, and hsaturn/EspMock v0.1.
 * v1.2.0 (2022-11-04)
     * Replace `LocalDate::kEpochYear` with `HardwareDateTime::kBaseYear`
       since AceTime current epoch is no longer a constant and AceTime no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* v1.2.1 (2022-11-06)
     * Fix incorrect reference to
      `LocalDate::secondsToCurrentEpochFromUnixEpoch64` instead of
      `Epoch::secondsToCurrentEpochFromUnixEpoch64`.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ in the future.
 This library can be an alternative to the Arduino Time
 (https://github.com/PaulStoffregen/Time) library.
 
-**Version**: v1.2.0 (2022-11-04)
+**Version**: v1.2.1 (2022-11-06)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ machine, you need:
 
 * AUnit (https://github.com/bxparks/AUnit)
 * EpoxyDuino (https://github.com/bxparks/EpoxyDuino)
+* EspMock (https://github.com/hsaturn/EspMock)
 
 <a name="Documentation"></a>
 ## Documentation

--- a/docs/doxygen.cfg
+++ b/docs/doxygen.cfg
@@ -38,7 +38,7 @@ PROJECT_NAME           = AceTimeClock
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.2.0
+PROJECT_NUMBER         = 1.2.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/html/AceTimeClock_8h_source.html
+++ b/docs/html/AceTimeClock_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>
@@ -99,8 +99,8 @@ $(function() {
 <div class="line"><a name="l00037"></a><span class="lineno">   37</span>&#160;<span class="preprocessor">#endif </span><span class="comment">// #if defined(ARDUINO_ARCH_STM32) || defined(EPOXY_DUINO)</span></div>
 <div class="line"><a name="l00038"></a><span class="lineno">   38</span>&#160; </div>
 <div class="line"><a name="l00039"></a><span class="lineno">   39</span>&#160;<span class="comment">// Version format: xxyyzz == &quot;xx.yy.zz&quot;</span></div>
-<div class="line"><a name="l00040"></a><span class="lineno">   40</span>&#160;<span class="preprocessor">#define ACE_TIME_CLOCK_VERSION 10200</span></div>
-<div class="line"><a name="l00041"></a><span class="lineno">   41</span>&#160;<span class="preprocessor">#define ACE_TIME_CLOCK_VERSION_STRING &quot;1.2.0&quot;</span></div>
+<div class="line"><a name="l00040"></a><span class="lineno">   40</span>&#160;<span class="preprocessor">#define ACE_TIME_CLOCK_VERSION 10201</span></div>
+<div class="line"><a name="l00041"></a><span class="lineno">   41</span>&#160;<span class="preprocessor">#define ACE_TIME_CLOCK_VERSION_STRING &quot;1.2.1&quot;</span></div>
 <div class="line"><a name="l00042"></a><span class="lineno">   42</span>&#160; </div>
 <div class="line"><a name="l00043"></a><span class="lineno">   43</span>&#160;<span class="preprocessor">#endif</span></div>
 </div><!-- fragment --></div><!-- contents -->

--- a/docs/html/ClockInterface_8h_source.html
+++ b/docs/html/ClockInterface_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/Clock_8h_source.html
+++ b/docs/html/Clock_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/DS3231Clock_8h_source.html
+++ b/docs/html/DS3231Clock_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/DS3231_8h_source.html
+++ b/docs/html/DS3231_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/EspSntpClock_8cpp_source.html
+++ b/docs/html/EspSntpClock_8cpp_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>
@@ -74,7 +74,7 @@ $(function() {
 <div class="fragment"><div class="line"><a name="l00001"></a><span class="lineno">    1</span>&#160;<span class="preprocessor">#include &lt;Arduino.h&gt;</span></div>
 <div class="line"><a name="l00002"></a><span class="lineno">    2</span>&#160;<span class="preprocessor">#include &quot;EspSntpClock.h&quot;</span></div>
 <div class="line"><a name="l00003"></a><span class="lineno">    3</span>&#160; </div>
-<div class="line"><a name="l00004"></a><span class="lineno">    4</span>&#160;<span class="preprocessor">#if defined(ESP8266) || defined(ESP32)</span></div>
+<div class="line"><a name="l00004"></a><span class="lineno">    4</span>&#160;<span class="preprocessor">#if defined(ESP8266) || defined(ESP32) || defined(EPOXY_CORE_ESP8266)</span></div>
 <div class="line"><a name="l00005"></a><span class="lineno">    5</span>&#160; </div>
 <div class="line"><a name="l00006"></a><span class="lineno">    6</span>&#160;<span class="keyword">namespace </span>ace_time {</div>
 <div class="line"><a name="l00007"></a><span class="lineno">    7</span>&#160;<span class="keyword">namespace </span>clock {</div>

--- a/docs/html/EspSntpClock_8h_source.html
+++ b/docs/html/EspSntpClock_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>
@@ -79,7 +79,7 @@ $(function() {
 <div class="line"><a name="l00006"></a><span class="lineno">    6</span>&#160;<span class="preprocessor">#ifndef ACE_TIME_ESP_SNTP_CLOCK_H</span></div>
 <div class="line"><a name="l00007"></a><span class="lineno">    7</span>&#160;<span class="preprocessor">#define ACE_TIME_ESP_SNTP_CLOCK_H</span></div>
 <div class="line"><a name="l00008"></a><span class="lineno">    8</span>&#160; </div>
-<div class="line"><a name="l00009"></a><span class="lineno">    9</span>&#160;<span class="preprocessor">#if defined(ESP8266) || defined(ESP32)</span></div>
+<div class="line"><a name="l00009"></a><span class="lineno">    9</span>&#160;<span class="preprocessor">#if defined(ESP8266) || defined(ESP32) || defined(EPOXY_CORE_ESP8266)</span></div>
 <div class="line"><a name="l00010"></a><span class="lineno">   10</span>&#160; </div>
 <div class="line"><a name="l00011"></a><span class="lineno">   11</span>&#160;<span class="preprocessor">#include &lt;time.h&gt;</span> <span class="comment">// time()</span></div>
 <div class="line"><a name="l00012"></a><span class="lineno">   12</span>&#160;<span class="preprocessor">#include &lt;AceTime.h&gt;</span> <span class="comment">// LocalDate</span></div>
@@ -102,7 +102,7 @@ $(function() {
 <div class="line"><a name="l00049"></a><span class="lineno">   49</span>&#160; </div>
 <div class="line"><a name="l00050"></a><span class="lineno"><a class="line" href="classace__time_1_1clock_1_1EspSntpClock.html#ac57165f88b58b43ed9572bd183cff158">   50</a></span>&#160;    acetime_t <a class="code" href="classace__time_1_1clock_1_1EspSntpClock.html#ac57165f88b58b43ed9572bd183cff158">getNow</a>()<span class="keyword"> const override </span>{</div>
 <div class="line"><a name="l00051"></a><span class="lineno">   51</span>&#160;      <span class="keywordflow">return</span> time(<span class="keyword">nullptr</span>)</div>
-<div class="line"><a name="l00052"></a><span class="lineno">   52</span>&#160;        - LocalDate::secondsToCurrentEpochFromUnixEpoch64();</div>
+<div class="line"><a name="l00052"></a><span class="lineno">   52</span>&#160;        - Epoch::secondsToCurrentEpochFromUnixEpoch64();</div>
 <div class="line"><a name="l00053"></a><span class="lineno">   53</span>&#160;    }</div>
 <div class="line"><a name="l00054"></a><span class="lineno">   54</span>&#160;};</div>
 <div class="line"><a name="l00055"></a><span class="lineno">   55</span>&#160; </div>

--- a/docs/html/HardwareDateTime_8cpp_source.html
+++ b/docs/html/HardwareDateTime_8cpp_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/HardwareDateTime_8h_source.html
+++ b/docs/html/HardwareDateTime_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/HardwareTemperature_8h_source.html
+++ b/docs/html/HardwareTemperature_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/NtpClock_8cpp_source.html
+++ b/docs/html/NtpClock_8cpp_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>
@@ -79,7 +79,7 @@ $(function() {
 <div class="line"><a name="l00006"></a><span class="lineno">    6</span>&#160;<span class="preprocessor">#include &lt;Arduino.h&gt;</span></div>
 <div class="line"><a name="l00007"></a><span class="lineno">    7</span>&#160;<span class="preprocessor">#include &quot;NtpClock.h&quot;</span></div>
 <div class="line"><a name="l00008"></a><span class="lineno">    8</span>&#160; </div>
-<div class="line"><a name="l00009"></a><span class="lineno">    9</span>&#160;<span class="preprocessor">#if defined(ESP8266) || defined(ESP32)</span></div>
+<div class="line"><a name="l00009"></a><span class="lineno">    9</span>&#160;<span class="preprocessor">#if defined(ESP8266) || defined(ESP32) || defined(EPOXY_CORE_ESP8266)</span></div>
 <div class="line"><a name="l00010"></a><span class="lineno">   10</span>&#160; </div>
 <div class="line"><a name="l00011"></a><span class="lineno">   11</span>&#160;<span class="comment">// ESP32 does not define SERIAL_PORT_MONITOR</span></div>
 <div class="line"><a name="l00012"></a><span class="lineno">   12</span>&#160;<span class="preprocessor">#ifndef SERIAL_PORT_MONITOR</span></div>

--- a/docs/html/NtpClock_8h_source.html
+++ b/docs/html/NtpClock_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>
@@ -79,10 +79,10 @@ $(function() {
 <div class="line"><a name="l00006"></a><span class="lineno">    6</span>&#160;<span class="preprocessor">#ifndef ACE_TIME_NTP_CLOCK_H</span></div>
 <div class="line"><a name="l00007"></a><span class="lineno">    7</span>&#160;<span class="preprocessor">#define ACE_TIME_NTP_CLOCK_H</span></div>
 <div class="line"><a name="l00008"></a><span class="lineno">    8</span>&#160; </div>
-<div class="line"><a name="l00009"></a><span class="lineno">    9</span>&#160;<span class="preprocessor">#if defined(ESP8266) || defined(ESP32)</span></div>
+<div class="line"><a name="l00009"></a><span class="lineno">    9</span>&#160;<span class="preprocessor">#if defined(ESP8266) || defined(ESP32) || defined(EPOXY_CORE_ESP8266)</span></div>
 <div class="line"><a name="l00010"></a><span class="lineno">   10</span>&#160; </div>
 <div class="line"><a name="l00011"></a><span class="lineno">   11</span>&#160;<span class="preprocessor">#include &lt;stdint.h&gt;</span></div>
-<div class="line"><a name="l00012"></a><span class="lineno">   12</span>&#160;<span class="preprocessor">#if defined(ESP8266)</span></div>
+<div class="line"><a name="l00012"></a><span class="lineno">   12</span>&#160;<span class="preprocessor">#if defined(ESP8266) || defined(EPOXY_CORE_ESP8266)</span></div>
 <div class="line"><a name="l00013"></a><span class="lineno">   13</span>&#160;<span class="preprocessor">  #include &lt;ESP8266WiFi.h&gt;</span></div>
 <div class="line"><a name="l00014"></a><span class="lineno">   14</span>&#160;<span class="preprocessor">#else</span></div>
 <div class="line"><a name="l00015"></a><span class="lineno">   15</span>&#160;<span class="preprocessor">  #include &lt;WiFi.h&gt;</span></div>
@@ -155,7 +155,7 @@ $(function() {
 <div class="line"><a name="l00132"></a><span class="lineno">  132</span>&#160;}</div>
 <div class="line"><a name="l00133"></a><span class="lineno">  133</span>&#160;}</div>
 <div class="line"><a name="l00134"></a><span class="lineno">  134</span>&#160; </div>
-<div class="line"><a name="l00135"></a><span class="lineno">  135</span>&#160;<span class="preprocessor">#endif </span><span class="comment">// defined(ESP8266) || defined(ESP32)</span></div>
+<div class="line"><a name="l00135"></a><span class="lineno">  135</span>&#160;<span class="preprocessor">#endif</span></div>
 <div class="line"><a name="l00136"></a><span class="lineno">  136</span>&#160; </div>
 <div class="line"><a name="l00137"></a><span class="lineno">  137</span>&#160;<span class="preprocessor">#endif</span></div>
 <div class="ttc" id="aclassace__time_1_1clock_1_1Clock_html"><div class="ttname"><a href="classace__time_1_1clock_1_1Clock.html">ace_time::clock::Clock</a></div><div class="ttdoc">Abstract base class for objects that provide and store time.</div><div class="ttdef"><b>Definition:</b> <a href="Clock_8h_source.html#l00019">Clock.h:19</a></div></div>

--- a/docs/html/Stm32F1Clock_8h_source.html
+++ b/docs/html/Stm32F1Clock_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/Stm32F1Rtc_8cpp_source.html
+++ b/docs/html/Stm32F1Rtc_8cpp_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/Stm32F1Rtc_8h_source.html
+++ b/docs/html/Stm32F1Rtc_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/StmRtcClock_8h_source.html
+++ b/docs/html/StmRtcClock_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/StmRtc_8cpp_source.html
+++ b/docs/html/StmRtc_8cpp_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/StmRtc_8h_source.html
+++ b/docs/html/StmRtc_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/SystemClockCoroutine_8h_source.html
+++ b/docs/html/SystemClockCoroutine_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/SystemClockLoop_8h_source.html
+++ b/docs/html/SystemClockLoop_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/SystemClock_8h_source.html
+++ b/docs/html/SystemClock_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/UnixClock_8h_source.html
+++ b/docs/html/UnixClock_8h_source.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/annotated.html
+++ b/docs/html/annotated.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1Clock-members.html
+++ b/docs/html/classace__time_1_1clock_1_1Clock-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1Clock.html
+++ b/docs/html/classace__time_1_1clock_1_1Clock.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1DS3231Clock-members.html
+++ b/docs/html/classace__time_1_1clock_1_1DS3231Clock-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1DS3231Clock.html
+++ b/docs/html/classace__time_1_1clock_1_1DS3231Clock.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1EspSntpClock-members.html
+++ b/docs/html/classace__time_1_1clock_1_1EspSntpClock-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1EspSntpClock.html
+++ b/docs/html/classace__time_1_1clock_1_1EspSntpClock.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1NtpClock-members.html
+++ b/docs/html/classace__time_1_1clock_1_1NtpClock-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1NtpClock.html
+++ b/docs/html/classace__time_1_1clock_1_1NtpClock.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1Stm32F1Clock-members.html
+++ b/docs/html/classace__time_1_1clock_1_1Stm32F1Clock-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1Stm32F1Clock.html
+++ b/docs/html/classace__time_1_1clock_1_1Stm32F1Clock.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1StmRtcClock-members.html
+++ b/docs/html/classace__time_1_1clock_1_1StmRtcClock-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1StmRtcClock.html
+++ b/docs/html/classace__time_1_1clock_1_1StmRtcClock.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1SystemClockLoopTemplate-members.html
+++ b/docs/html/classace__time_1_1clock_1_1SystemClockLoopTemplate-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1SystemClockLoopTemplate.html
+++ b/docs/html/classace__time_1_1clock_1_1SystemClockLoopTemplate.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1SystemClockTemplate-members.html
+++ b/docs/html/classace__time_1_1clock_1_1SystemClockTemplate-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1SystemClockTemplate.html
+++ b/docs/html/classace__time_1_1clock_1_1SystemClockTemplate.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1UnixClock-members.html
+++ b/docs/html/classace__time_1_1clock_1_1UnixClock-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1clock_1_1UnixClock.html
+++ b/docs/html/classace__time_1_1clock_1_1UnixClock.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1hw_1_1ClockInterface-members.html
+++ b/docs/html/classace__time_1_1hw_1_1ClockInterface-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1hw_1_1ClockInterface.html
+++ b/docs/html/classace__time_1_1hw_1_1ClockInterface.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1hw_1_1DS3231-members.html
+++ b/docs/html/classace__time_1_1hw_1_1DS3231-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1hw_1_1DS3231.html
+++ b/docs/html/classace__time_1_1hw_1_1DS3231.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1hw_1_1StmRtc-members.html
+++ b/docs/html/classace__time_1_1hw_1_1StmRtc-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classace__time_1_1hw_1_1StmRtc.html
+++ b/docs/html/classace__time_1_1hw_1_1StmRtc.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/classes.html
+++ b/docs/html/classes.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/dir_173dd563440c1e02d7e3957b90659cd7.html
+++ b/docs/html/dir_173dd563440c1e02d7e3957b90659cd7.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/dir_1a3db1509c5a81eeb8e8fbfe5ac0febc.html
+++ b/docs/html/dir_1a3db1509c5a81eeb8e8fbfe5ac0febc.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/dir_68267d1309a1af8e8297ef4c3efbcdba.html
+++ b/docs/html/dir_68267d1309a1af8e8297ef4c3efbcdba.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/dir_710a5327734d15938c9752b39a7d94e5.html
+++ b/docs/html/dir_710a5327734d15938c9752b39a7d94e5.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/files.html
+++ b/docs/html/files.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/functions.html
+++ b/docs/html/functions.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/functions_func.html
+++ b/docs/html/functions_func.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/functions_vars.html
+++ b/docs/html/functions_vars.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/graph_legend.html
+++ b/docs/html/graph_legend.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/hierarchy.html
+++ b/docs/html/hierarchy.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/inherits.html
+++ b/docs/html/inherits.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/structace__time_1_1hw_1_1HardwareDateTime-members.html
+++ b/docs/html/structace__time_1_1hw_1_1HardwareDateTime-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/structace__time_1_1hw_1_1HardwareDateTime.html
+++ b/docs/html/structace__time_1_1hw_1_1HardwareDateTime.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/structace__time_1_1hw_1_1HardwareTemperature-members.html
+++ b/docs/html/structace__time_1_1hw_1_1HardwareTemperature-members.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/docs/html/structace__time_1_1hw_1_1HardwareTemperature.html
+++ b/docs/html/structace__time_1_1hw_1_1HardwareTemperature.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">AceTimeClock
-   &#160;<span id="projectnumber">1.2.0</span>
+   &#160;<span id="projectnumber">1.2.1</span>
    </div>
    <div id="projectbrief">Clock classes for Arduino that can synchronize from an NTP server or an RTC chip</div>
   </td>

--- a/examples/HelloEspSntpClock/HelloEspSntpClock.ino
+++ b/examples/HelloEspSntpClock/HelloEspSntpClock.ino
@@ -11,14 +11,14 @@
  * ...
  */
 
-#if !defined(ESP32) && !defined(ESP8266)
+#if !defined(ESP32) && !defined(ESP8266) && !defined(EPOXY_CORE_ESP8266)
   #error This sketch works only for the ESP8266 and ESP32
 #endif
 
 #include <Arduino.h>
 #include <AceTime.h>
 #include <AceTimeClock.h>
-#if defined(ESP8266)
+#if defined(ESP8266) || defined(EPOXY_CORE_ESP8266)
   #include <ESP8266WiFi.h>
 #else
   #include <WiFi.h>
@@ -36,13 +36,19 @@ using ace_time::clock::EspSntpClock;
 #define SERIAL_PORT_MONITOR Serial
 #endif
 
-// Replace WIFI_SSID and WIFI_PASSWORD with your WiFi SSID and password.
-// (I have a wrapper script that replaces these with the the correct values.
-// You will have to replace them manually.)
-// WARNING: For security, do NOT commit your ssid and password into a public
-// source repository.
+// Define your WiFi SSID and password.
+// 1) The Arduino IDE has no support for defining C preprocessor macros, so you
+// have to manually define them here. (WARNING: For security, do NOT commit your
+// ssid and password into a public source repository.)
+// 2) The auniter.sh script from the AUniter project allows the WIFI_SSID and
+// WIFI_PASSWORD macros to be defined on the command line or from a config file.
+#if defined(AUNITER)
 static const char SSID[] = WIFI_SSID;
 static const char PASSWORD[] = WIFI_PASSWORD;
+#else
+static const char SSID[] = "your wifi ssid";
+static const char PASSWORD[] = "your wifi passord";
+#endif
 
 // Number of millis to wait for WiFi connection before doing a software reboot.
 static const unsigned long REBOOT_TIMEOUT_MILLIS = 15000;

--- a/examples/HelloEspSntpClock/Makefile
+++ b/examples/HelloEspSntpClock/Makefile
@@ -1,0 +1,10 @@
+# See https://github.com/bxparks/EpoxyDuino for documentation about this
+# Makefile to compile and run Arduino programs natively on Linux or MacOS.
+
+APP_NAME := HelloEspSntpClock
+ARDUINO_LIBS := AceCommon AceSorting AceTime AceTimeClock AceRoutine \
+	ESP8266WiFi EpoxyMockSTM32RTC
+ARDUINO_LIB_DIRS := $(abspath ../../..) $(abspath ../../../EspMock/libraries)
+EPOXY_CORE := EPOXY_CORE_ESP8266
+MORE_CLEAN := more_clean
+include ../../../EpoxyDuino/EpoxyDuino.mk

--- a/examples/HelloNtpClock/HelloNtpClock.ino
+++ b/examples/HelloNtpClock/HelloNtpClock.ino
@@ -11,14 +11,14 @@
  * ...
  */
 
-#if !defined(ESP32) && !defined(ESP8266)
+#if !defined(ESP32) && !defined(ESP8266) && !defined(EPOXY_CORE_ESP8266)
   #error This sketch works only for the ESP8266 and ESP32
 #endif
 
 #include <Arduino.h>
 #include <AceTime.h>
 #include <AceTimeClock.h>
-#if defined(ESP8266)
+#if defined(ESP8266) || defined(EPOXY_CORE_ESP8266)
   #include <ESP8266WiFi.h>
 #else
   #include <WiFi.h>
@@ -36,14 +36,19 @@ using ace_time::clock::NtpClock;
 #define SERIAL_PORT_MONITOR Serial
 #endif
 
-// Replace WIFI_SSID and WIFI_PASSWORD with your WiFi SSID and password. I have
-// a wrapper script that replaces these with the correct values. You will have
-// to replace them manually.
-//
-// WARNING: For security, do NOT commit your ssid and password into a public
-// source repository.
+// Define your WiFi SSID and password.
+// 1) The Arduino IDE has no support for defining C preprocessor macros, so you
+// have to manually define them here. (WARNING: For security, do NOT commit your
+// ssid and password into a public source repository.)
+// 2) The auniter.sh script from the AUniter project allows the WIFI_SSID and
+// WIFI_PASSWORD macros to be defined on the command line or from a config file.
+#if defined(AUNITER)
 static const char SSID[] = WIFI_SSID;
 static const char PASSWORD[] = WIFI_PASSWORD;
+#else
+static const char SSID[] = "your wifi ssid";
+static const char PASSWORD[] = "your wifi passord";
+#endif
 // Number of millis to wait for WiFi connection before doing a software reboot.
 static const unsigned long REBOOT_TIMEOUT_MILLIS = 15000;
 

--- a/examples/HelloNtpClock/Makefile
+++ b/examples/HelloNtpClock/Makefile
@@ -1,0 +1,10 @@
+# See https://github.com/bxparks/EpoxyDuino for documentation about this
+# Makefile to compile and run Arduino programs natively on Linux or MacOS.
+
+APP_NAME := HelloNtpClock
+ARDUINO_LIBS := AceCommon AceSorting AceTime AceTimeClock AceRoutine \
+	ESP8266WiFi EpoxyMockSTM32RTC
+ARDUINO_LIB_DIRS := $(abspath ../../..) $(abspath ../../../EspMock/libraries)
+EPOXY_CORE := EPOXY_CORE_ESP8266
+MORE_CLEAN := more_clean
+include ../../../EpoxyDuino/EpoxyDuino.mk

--- a/examples/HelloNtpClockLazy/HelloNtpClockLazy.ino
+++ b/examples/HelloNtpClockLazy/HelloNtpClockLazy.ino
@@ -10,7 +10,7 @@
  * ...
  */
 
-#if !defined(ESP32) && !defined(ESP8266)
+#if !defined(ESP32) && !defined(ESP8266) && !defined(EPOXY_CORE_ESP8266)
   #error This sketch works only for the ESP8266 and ESP32
 #endif
 
@@ -30,14 +30,19 @@ using ace_time::clock::NtpClock;
 #define SERIAL_PORT_MONITOR Serial
 #endif
 
-// Replace WIFI_SSID and WIFI_PASSWORD with your WiFi SSID and password. I have
-// a wrapper script that replaces these with the correct values. You will have
-// to replace them manually.
-//
-// WARNING: For security, do NOT commit your ssid and password into a public
-// source repository.
+// Define your WiFi SSID and password.
+// 1) The Arduino IDE has no support for defining C preprocessor macros, so you
+// have to manually define them here. (WARNING: For security, do NOT commit your
+// ssid and password into a public source repository.)
+// 2) The auniter.sh script from the AUniter project allows the WIFI_SSID and
+// WIFI_PASSWORD macros to be defined on the command line or from a config file.
+#if defined(AUNITER)
 static const char SSID[] = WIFI_SSID;
 static const char PASSWORD[] = WIFI_PASSWORD;
+#else
+static const char SSID[] = "your wifi ssid";
+static const char PASSWORD[] = "your wifi passord";
+#endif
 static const unsigned long WIFI_TIMEOUT_MILLIS = 15000;
 
 static BasicZoneProcessor parisProcessor;

--- a/examples/HelloNtpClockLazy/Makefile
+++ b/examples/HelloNtpClockLazy/Makefile
@@ -1,0 +1,10 @@
+# See https://github.com/bxparks/EpoxyDuino for documentation about this
+# Makefile to compile and run Arduino programs natively on Linux or MacOS.
+
+APP_NAME := HelloNtpClockLazy
+ARDUINO_LIBS := AceCommon AceSorting AceTime AceTimeClock AceRoutine \
+	ESP8266WiFi EpoxyMockSTM32RTC
+ARDUINO_LIB_DIRS := $(abspath ../../..) $(abspath ../../../EspMock/libraries)
+EPOXY_CORE := EPOXY_CORE_ESP8266
+MORE_CLEAN := more_clean
+include ../../../EpoxyDuino/EpoxyDuino.mk

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,8 +1,28 @@
+# These examples use ESP_CORE_AVR (default), which requires a recompilation
+# if ESP_CORE_ESP8266 was used previously, so perform a clean to be sure.
+AVR_EXAMPLES := AutoBenchmark HelloDS3231Clock HelloStm32F1Clock \
+	HelloStmRtcClock HelloSystemClockCoroutine HelloSystemClockLoop \
+	MemoryBenchmark
+
+# These examples use ESP_CORE_ESP8266, which requires a recompilation,
+# if ESP_CORE_AVR was used previously, so perform a clean to be sure.
+ESP8266_EXAMPLES := HelloEspSntpClock HelloNtpClock HelloNtpClockLazy
+
+# The two sets of example apps must be compiled sequentially to prevent one set
+# from interfering with the other. Various object files need to be compiled
+# with different preprocessor macros.
 all:
+	$(MAKE) clean
 	set -e; \
-	for i in */Makefile; do \
-		echo '==== Making:' $$(dirname $$i); \
-		$(MAKE) -C $$(dirname $$i) -j; \
+	for i in $(AVR_EXAMPLES); do \
+		echo '==== Making:' $$i; \
+		$(MAKE) -C $$i; \
+	done; \
+	$(MAKE) clean; \
+	set -e; \
+	for i in $(ESP8266_EXAMPLES); do \
+		echo '==== Making:' $$i; \
+		$(MAKE) -C $$i; \
 	done
 
 clean:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -10,7 +10,9 @@ ESP8266_EXAMPLES := HelloEspSntpClock HelloNtpClock HelloNtpClockLazy
 
 # The two sets of example apps must be compiled sequentially to prevent one set
 # from interfering with the other. Various object files need to be compiled
-# with different preprocessor macros.
+# with different preprocessor macros. This calls 'make clean' at the very end
+# so that targets that come after the EPOXY_CORE_ESP8266 examples to revert
+# back to EPOXY_CORE__AVR.
 all:
 	$(MAKE) clean
 	set -e; \
@@ -23,7 +25,8 @@ all:
 	for i in $(ESP8266_EXAMPLES); do \
 		echo '==== Making:' $$i; \
 		$(MAKE) -C $$i; \
-	done
+	done; \
+	$(MAKE) clean
 
 clean:
 	set -e; \

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AceTimeClock
-version=1.2.0
+version=1.2.1
 author=Brian T. Park <brian@xparks.net>
 maintainer=Brian T. Park <brian@xparks.net>
 sentence=Clock classes for Arduino that can synchronize from an NTP server or an RTC chip.

--- a/src/AceTimeClock.h
+++ b/src/AceTimeClock.h
@@ -37,7 +37,7 @@
 #endif // #if defined(ARDUINO_ARCH_STM32) || defined(EPOXY_DUINO)
 
 // Version format: xxyyzz == "xx.yy.zz"
-#define ACE_TIME_CLOCK_VERSION 10200
-#define ACE_TIME_CLOCK_VERSION_STRING "1.2.0"
+#define ACE_TIME_CLOCK_VERSION 10201
+#define ACE_TIME_CLOCK_VERSION_STRING "1.2.1"
 
 #endif

--- a/src/ace_time/clock/EspSntpClock.cpp
+++ b/src/ace_time/clock/EspSntpClock.cpp
@@ -1,7 +1,7 @@
 #include <Arduino.h>
 #include "EspSntpClock.h"
 
-#if defined(ESP8266) || defined(ESP32)
+#if defined(ESP8266) || defined(ESP32) || defined(EPOXY_CORE_ESP8266)
 
 namespace ace_time {
 namespace clock {

--- a/src/ace_time/clock/EspSntpClock.h
+++ b/src/ace_time/clock/EspSntpClock.h
@@ -49,7 +49,7 @@ class EspSntpClock: public Clock {
 
     acetime_t getNow() const override {
       return time(nullptr)
-        - LocalDate::secondsToCurrentEpochFromUnixEpoch64();
+        - Epoch::secondsToCurrentEpochFromUnixEpoch64();
     }
 };
 

--- a/src/ace_time/clock/EspSntpClock.h
+++ b/src/ace_time/clock/EspSntpClock.h
@@ -6,7 +6,7 @@
 #ifndef ACE_TIME_ESP_SNTP_CLOCK_H
 #define ACE_TIME_ESP_SNTP_CLOCK_H
 
-#if defined(ESP8266) || defined(ESP32)
+#if defined(ESP8266) || defined(ESP32) || defined(EPOXY_CORE_ESP8266)
 
 #include <time.h> // time()
 #include <AceTime.h> // LocalDate

--- a/src/ace_time/clock/NtpClock.cpp
+++ b/src/ace_time/clock/NtpClock.cpp
@@ -6,7 +6,7 @@
 #include <Arduino.h>
 #include "NtpClock.h"
 
-#if defined(ESP8266) || defined(ESP32)
+#if defined(ESP8266) || defined(ESP32) || defined(EPOXY_CORE_ESP8266)
 
 // ESP32 does not define SERIAL_PORT_MONITOR
 #ifndef SERIAL_PORT_MONITOR

--- a/src/ace_time/clock/NtpClock.h
+++ b/src/ace_time/clock/NtpClock.h
@@ -6,10 +6,10 @@
 #ifndef ACE_TIME_NTP_CLOCK_H
 #define ACE_TIME_NTP_CLOCK_H
 
-#if defined(ESP8266) || defined(ESP32)
+#if defined(ESP8266) || defined(ESP32) || defined(EPOXY_CORE_ESP8266)
 
 #include <stdint.h>
-#if defined(ESP8266)
+#if defined(ESP8266) || defined(EPOXY_CORE_ESP8266)
   #include <ESP8266WiFi.h>
 #else
   #include <WiFi.h>
@@ -132,6 +132,6 @@ class NtpClock: public Clock {
 }
 }
 
-#endif // defined(ESP8266) || defined(ESP32)
+#endif
 
 #endif


### PR DESCRIPTION
* v1.2.1 (2022-11-06)
    * Fix incorrect reference to
     `LocalDate::secondsToCurrentEpochFromUnixEpoch64` instead of
     `Epoch::secondsToCurrentEpochFromUnixEpoch64`.
    * Enable GitHub Actions for ESP8266 examples (HelloEspSntpClock,
      HelloNtpClock, HelloNtpClockLazy) to catch compiler errors.
        * Depends on EpoxyDuino v1.4.0, and hsaturn/EspMock v0.1.
