### PR TITLE
Add Teensy RTC clock class. Make NtpClock compatible with Teensy.

### DIFF
--- a/src/AceTimeClock.h
+++ b/src/AceTimeClock.h
@@ -31,6 +31,10 @@
 #include "ace_time/clock/SystemClockLoop.h"
 #include "ace_time/clock/SystemClockCoroutine.h"
 
+#if defined(TEENSYDUINO)
+#include "ace_time/clock/TeensyRtcClock.h"
+#endif
+
 #if defined(ARDUINO_ARCH_STM32) || defined(EPOXY_DUINO)
 #include "ace_time/clock/StmRtcClock.h"
 #include "ace_time/clock/Stm32F1Clock.h"

--- a/src/ace_time/clock/NtpClock.h
+++ b/src/ace_time/clock/NtpClock.h
@@ -6,19 +6,24 @@
 #ifndef ACE_TIME_NTP_CLOCK_H
 #define ACE_TIME_NTP_CLOCK_H
 
-#if defined(ESP8266) || defined(ESP32) || defined(EPOXY_CORE_ESP8266)
+// #if defined(ESP8266) || defined(ESP32) || defined(EPOXY_CORE_ESP8266)
 
 #include <stdint.h>
 #if defined(ESP8266) || defined(EPOXY_CORE_ESP8266)
   #include <ESP8266WiFi.h>
-#else
+#elif defined(ESP32)
   #include <WiFi.h>
 #endif
-#include <WiFiUdp.h>
+#if defined(ESP8266) || defined(ESP32) || defined(EPOXY_CORE_ESP8266)
+  #include <WiFiUdp.h>
+#endif
+#if defined(TEENSYDUINO)
+  #include <NativeEthernet.h>
+#endif
 #include "Clock.h"
 
 #ifndef ACE_TIME_NTP_CLOCK_DEBUG
-#define ACE_TIME_NTP_CLOCK_DEBUG 0
+#define ACE_TIME_NTP_CLOCK_DEBUG 1
 #endif
 
 namespace ace_time {
@@ -107,9 +112,12 @@ class NtpClock: public Clock {
      *    (default 10000 ms)
      */
     void setup(
+#if defined(ESP8266) || defined(ESP32) || defined(EPOXY_CORE_ESP8266)
         const char* ssid = nullptr,
         const char* password = nullptr,
-        uint16_t connectTimeoutMillis = kConnectTimeoutMillis);
+#endif
+        uint16_t connectTimeoutMillis = kConnectTimeoutMillis
+    );
 
     /** Return the name of the NTP server. */
     const char* getServer() const { return mServer; }
@@ -160,7 +168,11 @@ class NtpClock: public Clock {
     uint16_t const mLocalPort;
     uint16_t const mRequestTimeout;
 
+#if defined(ESP8266) || defined(ESP32) || defined(EPOXY_CORE_ESP8266)
     mutable WiFiUDP mUdp;
+#elif defined(TEENSYDUINO)
+    mutable EthernetUDP mUdp;
+#endif
     // buffer to hold incoming & outgoing packets
     mutable uint8_t mPacketBuffer[kNtpPacketSize];
     bool mIsSetUp = false;
@@ -169,6 +181,6 @@ class NtpClock: public Clock {
 }
 }
 
-#endif
+// #endif
 
 #endif

--- a/src/ace_time/clock/SystemClockCoroutine.h
+++ b/src/ace_time/clock/SystemClockCoroutine.h
@@ -150,7 +150,7 @@ class SystemClockCoroutineTemplate :
             // Clobber the mRequestStatus to trigger the exponential backoff
             mRequestStatus = kStatusUnknown;
           } else {
-            this->syncNow(nowSeconds);
+            this->syncNow(nowSeconds, kSyncSourceReferenceClock);
             mCurrentSyncPeriodSeconds = mSyncPeriodSeconds;
             this->setSyncStatusCode(this->kSyncStatusOk);
           }

--- a/src/ace_time/clock/SystemClockLoop.h
+++ b/src/ace_time/clock/SystemClockLoop.h
@@ -116,7 +116,7 @@ class SystemClockLoopTemplate : public SystemClockTemplate<T_SCCI> {
               this->setSyncStatusCode(this->kSyncStatusError);
             } else {
               // Request succeeded.
-              this->syncNow(nowSeconds);
+              this->syncNow(nowSeconds, this->kSyncSourceReferenceClock);
               mCurrentSyncPeriodSeconds = mSyncPeriodSeconds;
               mRequestStatus = this->kStatusOk;
               this->setSyncStatusCode(this->kSyncStatusOk);

--- a/src/ace_time/clock/TeensyRtcClock.h
+++ b/src/ace_time/clock/TeensyRtcClock.h
@@ -1,0 +1,69 @@
+/*
+ * MIT License
+ * Copyright (c) 2024 Brian T. Park, Anatoli Arkhipenko, Alexander Zarubkin
+ * Based on StmRtcClock
+ *
+ */
+
+#ifndef ACE_TIME_TEENSY_RTC_CLOCK_H
+#define ACE_TIME_TEENSY_RTC_CLOCK_H
+
+#if defined(TEENSYDUINO)
+
+#include <stdint.h>
+#include <AceTime.h> // LocalDateTime
+#include "../hw/HardwareDateTime.h"
+#include "Clock.h"
+
+namespace ace_time {
+namespace clock {
+
+/**
+ * An implementation of Clock that uses an Teensy RTC chip using the
+ * [STM32RTC](https://github.com/stm32duino/STM32RTC) library. The STM32RTC
+ * singleton object should be configured using `STM32RTC::getInstance()` in the
+ * global `setup()` function.
+ *
+ * AceTime v2 allows the epoch year of the library to be adjustable by the
+ * client application, from the year 2000 until the year 10000. Unfortunately,
+ * the STM32 hardware supported by this class (through the dependent STM32RTC
+ * library) uses a 2-digit year offset from the year 2000. This will break in
+ * the year 2100 unless a software fix can be created to work around that
+ * limitation.
+ *
+ * Ironically, the STM32F1 chip has a more limited RTC functionality in the
+ * hardware but that limitation actually works to its advantage so that the F1
+ * can be fully compatible with AceTime to its limit of the year 10000 if
+ * Stm32F1Clock class is used instead of this class. (See notes in
+ * Stm32F1Clock.h).
+ */
+class TeensyRtcClock: public Clock {
+  public:
+    /** Constructor. */
+    explicit TeensyRtcClock() = default;
+
+    /** Setup does nothing. Defined for API consistency with other Clocks. */
+    void setup() {}
+
+    acetime_t getNow() const override {
+      time_t unixSeconds = Teensy3Clock.get(); // returns seconds since 1970-01-01 (Unix epoch)
+      // detect if RTC has not been set with correct time (e.g. starting without battery or with bad battery)
+      //TODO: will stop working after 2038
+      if(unixSeconds < 1714521600) // May 1 2024 00:00:00 UTC
+        return kInvalidSeconds;
+      return unixSeconds - Epoch::secondsToCurrentEpochFromUnixEpoch64();
+    }
+
+    void setNow(acetime_t epochSeconds) override {
+      if (epochSeconds == kInvalidSeconds) return;
+
+      time_t unixSeconds = epochSeconds + Epoch::secondsToCurrentEpochFromUnixEpoch64();
+      Teensy3Clock.set(unixSeconds);
+    }
+};
+
+} // hw
+} // ace_time
+
+#endif // #if defined(ARDUINO_ARCH_STM32) || defined(EPOXY_DUINO)
+#endif // #ifndef ACE_TIME_STM_RTC_CLOCK_H

--- a/src/ace_time/clock/TeensyRtcClock.h
+++ b/src/ace_time/clock/TeensyRtcClock.h
@@ -19,23 +19,13 @@ namespace ace_time {
 namespace clock {
 
 /**
- * An implementation of Clock that uses an Teensy RTC chip using the
- * [STM32RTC](https://github.com/stm32duino/STM32RTC) library. The STM32RTC
- * singleton object should be configured using `STM32RTC::getInstance()` in the
- * global `setup()` function.
- *
- * AceTime v2 allows the epoch year of the library to be adjustable by the
- * client application, from the year 2000 until the year 10000. Unfortunately,
- * the STM32 hardware supported by this class (through the dependent STM32RTC
- * library) uses a 2-digit year offset from the year 2000. This will break in
- * the year 2100 unless a software fix can be created to work around that
- * limitation.
- *
- * Ironically, the STM32F1 chip has a more limited RTC functionality in the
- * hardware but that limitation actually works to its advantage so that the F1
- * can be fully compatible with AceTime to its limit of the year 10000 if
- * Stm32F1Clock class is used instead of this class. (See notes in
- * Stm32F1Clock.h).
+ * An implementation of Clock that uses an Teensy RTC chip.
+ * It uses Teensy3Clock class to access the built-in RTC.
+ * Teensy firmware updater sets RTC to the current datetime of the computer it is running on.
+ * In hardware, it's implemented as 64-bit counter of 32 KHz ticks.
+ * Theoretically, it allows to use 64 - 15 == 49 bits as seconds counter.
+ * But Teensy3Clock.get() returns regular 32-bit Unix time.
+ * It's possible to write our own implementation of that class to use the full 49-bit range. Or maybe it's already patched in newer Teensyduino versions.
  */
 class TeensyRtcClock: public Clock {
   public:


### PR DESCRIPTION
Also add sync source to SystemClockTemplate to know what was the source the system clock was synced from (Reference, Backup, UserCode or Unknown (not synced)).