### PR TITLE
Adds NMEA based clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+    * Add NMEA as additional clock.
 * 1.3.0 (2023-07-20)
     * Replace call to `Epoch::daysToCurrentEpochFromConverterEpoch()` with
       `Epoch::daysToCurrentEpochFromInternalEpoch()`, to be consistent with

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following clock sources are supported:
 chip
 * the generic [STM32 RTC Clock](https://github.com/stm32duino/STM32RTC)
 * the special [STM32F1 RTC Clock](https://github.com/stm32duino/STM32RTC/issues/29)
+* an external NMEA compliant GPS receiver
 * an [NTP](https://en.wikipedia.org/wiki/Network_Time_Protocol) server
   using a hand-crafted NTP client
 * the SNTP client on ESP8266 and ESP32 platforms
@@ -49,7 +50,7 @@ complexity of both libraries.
 This library can be an alternative to the Arduino Time
 (https://github.com/PaulStoffregen/Time) library.
 
-**Version**: v1.3.0 (2023-07-20)
+**Version**: v1.3.1 (2025-08-09)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 
@@ -266,6 +267,8 @@ The following programs are provided in the `examples/` directory:
     * same as `HelloSystemClockLoop` but using AceRoutine coroutines
 * [HelloDS3231Clock](examples/HelloDS3231Clock/)
     * demo of `DS3231Clock<T>` template class using `<AceWire.h>`
+* [HelloNmeaClock](examples/HelloNmeaClock/)
+    * demo of `NmeaClock` on ESP8266 and ESP32
 * [HelloNtpClock](examples/HelloNtpClock/)
     * demo of `NtpClock` on ESP8266 and ESP32
 * [HelloNtpClockLazy](examples/HelloNtpClockLazy/)
@@ -343,6 +346,7 @@ and the diamond-line means "is-aggregation-of":
    |           |    StmRtcClock -----> hw::StmRtc ----> STM32RTC
    |           |    Stm32F1Clock ----> hw::Stm32F1Rtc
    |           |    UnixClock -------> time()
+   |           |    NmeaClock -------> supplied NMEA sentences
    |           |
    `---<> SystemClock
            ^       ^
@@ -355,6 +359,7 @@ These are arranged in the following C++ namespaces:
 * `ace_time::clock::Clock`
     * `ace_time::clock::DS3231Clock`
     * `ace_time::clock::EspSntpClock`
+    * `ace_time::clock::NmeaClock`
     * `ace_time::clock::NtpClock`
     * `ace_time::clock::StmRtcClock`
     * `ace_time::clock::Stm32F1Clock`

--- a/examples/HelloNmeaClock/HelloNmeaClock.ino
+++ b/examples/HelloNmeaClock/HelloNmeaClock.ino
@@ -1,0 +1,75 @@
+/*
+ * A program to demonstrate the use of the HelloNmeaClock<T> class. It should print
+ * the following on the SERIAL_PORT_MONITOR port every 2 seconds, if there is 
+ * a GPS receiver connected to pin 2:
+ *
+ *   2021-10-18T10:28:00
+ *   2021-10-18T10:28:02
+ *   2021-10-18T10:28:04
+ *   ...
+ */
+
+#include <Arduino.h>
+#include <AceTime.h> // TimeZone, LocalDateTime
+#include <AceTimeClock.h> // DS3231Clock
+#include <AceWire.h> // TwoWireInterface
+#include <Wire.h> // TwoWire, Wire
+
+#include <SoftwareSerial.h>
+
+using ace_time::acetime_t;
+using ace_time::TimeZone;
+using ace_time::ZonedDateTime;
+using ace_time::clock::NmeaClock;
+using ace_time::zonedb::kZoneAmerica_Los_Angeles;
+using ace_time::BasicZoneProcessor;
+
+// ESP32 does not define SERIAL_PORT_MONITOR
+#ifndef SERIAL_PORT_MONITOR
+#define SERIAL_PORT_MONITOR Serial
+#endif
+
+SoftwareSerial gpsSerial(13, -1);
+
+static BasicZoneProcessor losAngelesProcessor;
+
+TimeZone losAngelesTz = TimeZone::forZoneInfo(
+    &kZoneAmerica_Los_Angeles,
+    &losAngelesProcessor);
+
+//-----------------------------------------------------------------------------
+
+NmeaClock nmeaClock;
+
+void printCurrentTime() {
+  acetime_t now = nmeaClock.getNow();
+  ZonedDateTime zdt = ZonedDateTime::forEpochSeconds(now, losAngelesTz);
+  zdt.printTo(SERIAL_PORT_MONITOR);
+  SERIAL_PORT_MONITOR.println();
+}
+
+//-----------------------------------------------------------------------------
+
+void setup() {
+#if ! defined(EPOXY_DUINO)
+  delay(1000);
+#endif
+  SERIAL_PORT_MONITOR.begin(115200);
+  gpsSerial.begin(9600);
+  gpsSerial.listen();
+  while (!SERIAL_PORT_MONITOR); // Wait until ready - Leonardo/Micro
+}
+
+// Do NOT use delay() here.
+void loop() {
+  if (gpsSerial.available()) {
+    nmeaClock.parse(gpsSerial.read());
+  }
+
+  static uint16_t prevMillis;
+  uint16_t nowMillis = millis();
+  if ((uint16_t) (nowMillis - prevMillis) >= 2000) {
+    printCurrentTime();
+    prevMillis = nowMillis;
+  }
+}

--- a/examples/HelloNmeaClock/Makefile
+++ b/examples/HelloNmeaClock/Makefile
@@ -1,0 +1,6 @@
+# See https://github.com/bxparks/EpoxyDuino for documentation about this
+# Makefile to compile and run Arduino programs natively on Linux or MacOS.
+
+APP_NAME := HelloNmeaClock
+ARDUINO_LIBS := AceCommon AceSorting AceTime AceTimeClock AceWire
+include ../../../EpoxyDuino/EpoxyDuino.mk

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AceTimeClock
-version=1.3.0
+version=1.3.1
 author=Brian T. Park <brian@xparks.net>
 maintainer=Brian T. Park <brian@xparks.net>
 sentence=Clock classes for Arduino that provide an auto-incrementing count of seconds since a known epoch which can be synchronized from external sources such as an NTP server, a DS3231 RTC chip, or an STM32 RTC chip.

--- a/src/AceTimeClock.h
+++ b/src/AceTimeClock.h
@@ -23,6 +23,7 @@
 #endif
 
 #include "ace_time/clock/Clock.h"
+#include "ace_time/clock/NmeaClock.h"
 #include "ace_time/clock/NtpClock.h"
 #include "ace_time/clock/DS3231Clock.h"
 #include "ace_time/clock/UnixClock.h"

--- a/src/ace_time/clock/NmeaClock.cpp
+++ b/src/ace_time/clock/NmeaClock.cpp
@@ -7,6 +7,14 @@
 namespace ace_time {
 namespace clock {
 
+    IRAM_ATTR volatile uint32_t _nmeaMillisAtLastPPS;
+    IRAM_ATTR volatile uint32_t _nmeaSecondsFromPPS;
+    IRAM_ATTR void _nmeaPPShandler()
+    {
+        _nmeaMillisAtLastPPS = millis();
+        _nmeaSecondsFromPPS++;
+    }
+
     void NmeaClock::parse(int nmeaChar)
     {
         if (nmeaChar <= 0 || nmeaChar >= 0x7f) {
@@ -124,8 +132,14 @@ namespace clock {
         }
         // convert the GPS time to UTC
         ZonedDateTime zdt = ZonedDateTime::forComponents(year, month, day, hour, minute, second, TimeZone::forUtc());
-        m_lastSyncedGpsTime = zdt.toEpochSeconds();
+        acetime_t now = zdt.toEpochSeconds();
         m_millisAtLastSync = millis() - m_msOffsetPPStoMessage;
+        noInterrupts();
+        // set time and wait for next PPS
+        m_lastSyncedGpsTime = now;
+        _nmeaSecondsFromPPS = 0;
+        interrupts();
+        // Serial.printf("Got time %04d-%02d-%02d %02d:%02d:%02d %d %d\n", year, month, day, hour, minute, second, m_millisAtLastSync, _nmeaSecondsaFromPPS);
     }
 }
 }

--- a/src/ace_time/clock/NmeaClock.cpp
+++ b/src/ace_time/clock/NmeaClock.cpp
@@ -1,0 +1,131 @@
+/*
+ * MIT License
+ * Copyright (c) 2025 Wolfgang Jung
+ */
+#include "NmeaClock.h"
+
+namespace ace_time {
+namespace clock {
+
+    void NmeaClock::parse(int nmeaChar)
+    {
+        if (nmeaChar <= 0 || nmeaChar >= 0x7f) {
+            return;
+        }
+        if (nmeaChar == '$' || nmeaChar == '!') {
+            // start of message
+            m_recvState = IN_MESSAGE;
+            // start of message
+            m_runningCheckSum = 0;
+            m_checkSum = 0;
+            m_writePosition = 0;
+            return;
+        } else if (nmeaChar == '*') {
+            // start of checksum
+            m_recvState = IN_CHECKSUM;
+        } else if (m_writePosition >= 100) {
+            // message longer, than expected, ignore
+            m_recvState = WAIT_FOR_START;
+            return;
+        } else if (nmeaChar == '\n' || nmeaChar == '\r') {
+            // end of line, can occur twice (if windows line endings were sent)
+            if (m_recvState == IN_CHECKSUM) {
+                // parse the complete NMEA sentence
+                parseMessage();
+            }
+            m_recvState = WAIT_FOR_START;
+        }
+
+        if (m_recvState == IN_MESSAGE) {
+            // only xor the current char, if it is after the $ at the start and before the * mark for the hash
+            m_runningCheckSum ^= (uint8_t)nmeaChar;
+        } else if (m_recvState == IN_CHECKSUM && nmeaChar != '*') {
+            // parse the two digit checksum
+            m_checkSum = m_checkSum * 16 + parseHex(nmeaChar);
+        }
+        m_messageBuffer[m_writePosition++] = nmeaChar;
+        m_messageBuffer[m_writePosition] = '\0';
+    }
+
+    void NmeaClock::parseMessage()
+    {
+#ifdef NMEA_CLOCK_STATS
+        m_stats.m_messages++;
+#endif
+        if (m_checkSum != m_runningCheckSum) {
+#ifdef NMEA_CLOCK_STATS
+            m_stats.m_checksumFailed++;
+#endif
+            return;
+        }
+        // ignore non $GPRMC messages
+        if (strncmp(m_messageBuffer, "GPRMC", 5) != 0) {
+            return;
+        }
+
+        char* endOfCurrentToken = m_messageBuffer;
+        char* token = m_messageBuffer;
+
+        uint8_t field_count = 0;
+
+        char* time_str = nullptr;
+        char* date_str = nullptr;
+        bool valid_message = false;
+
+#ifdef NMEA_CLOCK_STATS
+        m_stats.m_gprmc++;
+#endif
+        while (*token != '\0' && field_count < 12) {
+            // strtok implementation, that handles empty fields
+            while (*endOfCurrentToken != '\0') {
+                if (*endOfCurrentToken == ',' || *endOfCurrentToken == '*') {
+                    *endOfCurrentToken = '\0';
+                    break;
+                }
+                endOfCurrentToken++;
+            }
+            // handle the three fields of interest
+            if (field_count == 1) {
+                time_str = token;
+            } else if (field_count == 2) {
+                // valid 'A' and invalid messages 'V'
+                valid_message = (token[0] == 'A');
+            } else if (field_count == 9) {
+                date_str = token;
+            }
+            // advance to the next token
+            token = endOfCurrentToken + 1;
+            endOfCurrentToken = token;
+            field_count++;
+        }
+
+        // Only process if message is valid and we have both time and date
+        if (!valid_message || time_str == nullptr || date_str == nullptr || strlen(time_str) < 6 || strlen(date_str) < 6 || field_count != 12) {
+#ifdef NMEA_CLOCK_STATS
+            m_stats.m_missingFields++;
+#endif
+            return;
+        }
+
+        // parse the date and time fields from the NMEA message
+        uint8_t hour = intValue(time_str + 0);
+        uint8_t minute = intValue(time_str + 2);
+        uint8_t second = intValue(time_str + 4);
+        uint8_t day = intValue(date_str + 0);
+        uint8_t month = intValue(date_str + 2);
+        uint16_t year = intValue(date_str + 4) + 2000; // pre 2000 messages will no longer be sent
+
+        // Validate ranges. And, yes, seconds can go from 0 to 60 inclusive
+        if (hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 60 || day < 1 || day > 31 || month < 1 || month > 12) {
+#ifdef NMEA_CLOCK_STATS
+            m_stats.m_invalidData++;
+#endif
+            return;
+        }
+        // convert the GPS time to UTC
+        ZonedDateTime zdt = ZonedDateTime::forComponents(year, month, day, hour, minute, second, TimeZone::forUtc());
+        m_lastSyncedGpsTime = zdt.toEpochSeconds();
+        m_millisAtLastSync = millis() - m_msOffsetPPStoMessage;
+    }
+}
+}

--- a/src/ace_time/clock/NmeaClock.h
+++ b/src/ace_time/clock/NmeaClock.h
@@ -1,0 +1,135 @@
+/*
+ * MIT License
+ * Copyright (c) 2025 Wolfgang Jung
+ */
+#ifndef ACE_TIME_NMEA_CLOCK_H
+#define ACE_TIME_NMEA_CLOCK_H
+
+#include <stdint.h>
+
+#include "Clock.h"
+
+namespace ace_time {
+namespace clock {
+
+#ifdef NMEA_CLOCK_STATS
+    /** Stats from the GPS driven clock. */
+    class NmeaClockStats {
+        friend class NmeaClock;
+
+        const uint32_t getMessages() { return m_messages; }
+        const uint32_t getChecksumFailed() { return m_checksumFailed; }
+        const uint32_t getGprmcMessages() { return m_gprmc; }
+        const uint32_t getMessagesWithMissingFields() { return m_missingFields; }
+        const uint32_t getMessagesWithMissingInvalidData() { return m_invalidData; }
+
+    private:
+        uint32_t m_messages;
+        uint32_t m_checksumFailed;
+        uint32_t m_gprmc;
+        uint32_t m_missingFields;
+        uint32_t m_invalidData;
+        uint32_t m_ageOfLastSync;
+    };
+#endif
+    /** A clock, that synchronizes to an external NMEA compliant GPS receiver.
+     *
+     * It can be used e.g. with a SoftwareSerial connection to the GPS receiver:
+     *
+     * static NmeaClock nmeaClock;
+     *  static SystemClockLoop systemClock(&nmeaClock, (Clock*)0);
+     *
+     *  SoftwareSerial gps(D7, -1);
+     *  void setup()
+     *  {
+     *      gps.begin(9600);
+     *      gps.listen();
+     *      systemClock.setup();
+     *  }
+     *  void loop()
+     *  {
+     *      systemClock.loop();
+     *      if (gps.available()) {
+     *          nmeaClock.parse(gps.read());
+     *      }
+     * ...
+     *  }
+     */
+    class NmeaClock : public Clock {
+    public:
+        /** Number of milliseconds after the second switch until the NMEA message is read. */
+        explicit NmeaClock(const uint16_t msOffsetPPStoMessage = 250)
+            : m_msOffsetPPStoMessage(msOffsetPPStoMessage)
+        {
+        }
+
+        /** parse a single char from the NMEA stream. */
+        void parse(const int nmeaChar);
+#ifdef NMEA_CLOCK_STATS
+        /** Stats about the clock. */
+        const NmeaClockStats& getStats() { return m_stats; }
+#endif
+
+        /** The expected current time accoroding to the last GPS sync, the time of that GPS sync
+         * and the current millis().
+         */
+        acetime_t getNow() const override
+        {
+            if (m_lastSyncedGpsTime == kInvalidSeconds) {
+                return kInvalidSeconds;
+            }
+            return m_lastSyncedGpsTime + ((millis() - m_millisAtLastSync) / 1000);
+        };
+
+        /** milis() when the last successful sync happened. */
+        const uint32_t getMillisOfLastSync() { return m_millisAtLastSync; }
+
+    private:
+        /** buffer, pointers and state for incoming messages */
+        char m_messageBuffer[100];
+        uint8_t m_writePosition = 0;
+        uint8_t m_checkSum;
+        uint8_t m_runningCheckSum;
+        enum RecvState {
+            WAIT_FOR_START,
+            IN_MESSAGE,
+            IN_CHECKSUM,
+        };
+        RecvState m_recvState;
+
+        /** average time between PPS and the receiving of the GPRMC message. */
+        const uint16_t m_msOffsetPPStoMessage;
+        /** Last known, valid, GPS time. */
+        acetime_t m_lastSyncedGpsTime = kInvalidSeconds;
+        /** System time of the the last GPS time to us, if GPS receiption is missing. */
+        uint32_t m_millisAtLastSync = 0;
+
+/** Some stats, enable with NMEA_CLOCK_STATS */
+#ifdef NMEA_CLOCK_STATS
+        const NmeaClockStats m_stats;
+#endif
+
+        uint8_t intValue(const char* twoDigitStr)
+        {
+            return (twoDigitStr[0] - '0') * 10 + (twoDigitStr[1] - '0');
+        }
+
+        void parseMessage();
+
+        uint8_t parseHex(char c)
+        {
+            if (c >= '0' && c <= '9') {
+                return c - '0';
+            } else if (c >= 'A' && c <= 'F') {
+                return c - 'A' + 10;
+            } else if (c >= 'a' && c <= 'f') {
+                return c - 'a' + 10;
+            }
+            return 0;
+        }
+    };
+
+}
+}
+
+#endif

--- a/src/ace_time/clock/NmeaClock.h
+++ b/src/ace_time/clock/NmeaClock.h
@@ -9,12 +9,17 @@
 
 #include "Clock.h"
 
+#ifndef IRAM_ATTR
+#define IRAM_ATTR
+#endif
+
 namespace ace_time {
 namespace clock {
 
 #ifdef NMEA_CLOCK_STATS
     /** Stats from the GPS driven clock. */
     class NmeaClockStats {
+    public:
         friend class NmeaClock;
 
         const uint32_t getMessages() { return m_messages; }
@@ -29,7 +34,6 @@ namespace clock {
         uint32_t m_gprmc;
         uint32_t m_missingFields;
         uint32_t m_invalidData;
-        uint32_t m_ageOfLastSync;
     };
 #endif
     /** A clock, that synchronizes to an external NMEA compliant GPS receiver.
@@ -55,12 +59,26 @@ namespace clock {
      * ...
      *  }
      */
+
+    extern IRAM_ATTR volatile uint32_t _nmeaMillisAtLastPPS;
+    extern IRAM_ATTR volatile uint32_t _nmeaSecondsFromPPS;
+    IRAM_ATTR void _nmeaPPShandler();
+
     class NmeaClock : public Clock {
     public:
-        /** Number of milliseconds after the second switch until the NMEA message is read. */
-        explicit NmeaClock(const uint16_t msOffsetPPStoMessage = 250)
+        /**
+         * @param msOffsetPPStoMessage Number of milliseconds after the second switch until the NMEA message is read.
+         * @param ppsPin Pin on which a PPS signal (rising edge) is applied to (optional)
+         */
+        explicit NmeaClock(const uint16_t msOffsetPPStoMessage = 250, const int8_t ppsPin = -1)
             : m_msOffsetPPStoMessage(msOffsetPPStoMessage)
+#ifdef NMEA_CLOCK_STATS
+            , m_stats(NmeaClockStats())
+#endif
         {
+            if (ppsPin >= 0) {
+                attachInterrupt(ppsPin, _nmeaPPShandler, RISING);
+            }
         }
 
         /** parse a single char from the NMEA stream. */
@@ -78,11 +96,16 @@ namespace clock {
             if (m_lastSyncedGpsTime == kInvalidSeconds) {
                 return kInvalidSeconds;
             }
-            return m_lastSyncedGpsTime + ((millis() - m_millisAtLastSync) / 1000);
+            uint32_t ppsAge = millis() - _nmeaMillisAtLastPPS;
+            if (ppsAge < 1010) { // even a fast running local clock should not run faster than 101%
+                return m_lastSyncedGpsTime + _nmeaSecondsFromPPS;
+            }
+            uint32_t syncAge = millis() - m_millisAtLastSync;
+            return m_lastSyncedGpsTime + (syncAge / 1000);
         };
-
         /** milis() when the last successful sync happened. */
-        const uint32_t getMillisOfLastSync() { return m_millisAtLastSync; }
+        const uint32_t getMillisOfLastSync() { return ::max(_nmeaMillisAtLastPPS, m_millisAtLastSync); }
+        const bool isPPSsynced() { return (millis() - _nmeaMillisAtLastPPS) < 1100; }
 
     private:
         /** buffer, pointers and state for incoming messages */
@@ -106,7 +129,7 @@ namespace clock {
 
 /** Some stats, enable with NMEA_CLOCK_STATS */
 #ifdef NMEA_CLOCK_STATS
-        const NmeaClockStats m_stats;
+        NmeaClockStats m_stats;
 #endif
 
         uint8_t intValue(const char* twoDigitStr)


### PR DESCRIPTION
I've added a simple NMEA parser as a new clock source. Now, this library can be used also in non-networked environments.

Unfortunately, I was unable to run the AUnit test with EpoxyDuino, but a sample deployment on an ESP32 works fine.
