### PR TITLE
Add Ethernet support to NtpClock using NetworkManager

### DIFF
--- a/src/ace_time/clock/NtpClock.cpp
+++ b/src/ace_time/clock/NtpClock.cpp
@@ -26,12 +26,15 @@ void NtpClock::setup(
   if (ssid) {
     WiFi.mode(WIFI_STA);
     WiFi.begin(ssid, password);
+    #if defined(ESP32)
+      Network.setDefaultInterface(WiFi.STA);
+    #endif
     uint16_t startMillis = millis();
     while (WiFi.status() != WL_CONNECTED) {
       uint16_t elapsedMillis = millis() - startMillis;
       if (elapsedMillis >= connectTimeoutMillis) {
       #if ACE_TIME_NTP_CLOCK_DEBUG >= 1
-        SERIAL_PORT_MONITOR.println(F("NtpClock::setup(): failed"));
+        SERIAL_PORT_MONITOR.println(F("NtpClock::setup(): Connecting to WiFi failed"));
       #endif
         mIsSetUp = false;
         return;
@@ -41,22 +44,43 @@ void NtpClock::setup(
     }
   }
 
-  mUdp.begin(mLocalPort);
-
-#if ACE_TIME_NTP_CLOCK_DEBUG >= 1
-  SERIAL_PORT_MONITOR.print(F("NtpClock::setup(): connected to"));
-  SERIAL_PORT_MONITOR.println(WiFi.localIP());
+  #if ACE_TIME_NTP_CLOCK_DEBUG >= 1
   #if defined(ESP8266)
-    SERIAL_PORT_MONITOR.print(F("Local port: "));
+  if(WiFi.status() == WL_CONNECTED){
+    SERIAL_PORT_MONITOR.print(F("NtpClock::setup(): connected to "));
+    SERIAL_PORT_MONITOR.println(WiFi.localIP());
+  #else
+  if(Network.getDefaultInterface()){
+    SERIAL_PORT_MONITOR.print(F("NtpClock::setup(): connected to "));
+    SERIAL_PORT_MONITOR.println(Network.getDefaultInterface()->localIP());
+  #endif
+  }
+  else{
+    SERIAL_PORT_MONITOR.println(F("NtpClock::setup(): network interface not ready"));
+  }
+  #endif
+
+  if(!mUdp.begin(mLocalPort)){
+    #if ACE_TIME_NTP_CLOCK_DEBUG >= 1
+      SERIAL_PORT_MONITOR.println(F("NtpClock::setup(): UDP bind failed"));
+    #endif
+    return;
+  }
+
+  #if ACE_TIME_NTP_CLOCK_DEBUG >= 1 && defined(ESP8266)
+    SERIAL_PORT_MONITOR.print(F("NtpClock::setup(): Local port: "));
     SERIAL_PORT_MONITOR.println(mUdp.localPort());
   #endif
-#endif
 
   mIsSetUp = true;
 }
 
 acetime_t NtpClock::getNow() const {
-  if (!mIsSetUp || WiFi.status() != WL_CONNECTED) return kInvalidSeconds;
+  #if defined(ESP8266) || defined(EPOXY_CORE_ESP8266)
+    if (!mIsSetUp || WiFi.status() != WL_CONNECTED) return kInvalidSeconds;
+  #else
+    if (!mIsSetUp || !(Network.getDefaultInterface() != NULL && Network.getDefaultInterface()->connected())) return kInvalidSeconds;
+  #endif
 
   sendRequest();
 
@@ -71,7 +95,12 @@ acetime_t NtpClock::getNow() const {
 
 void NtpClock::sendRequest() const {
   if (!mIsSetUp) return;
-  if (WiFi.status() != WL_CONNECTED) {
+  #if defined(ESP8266) || defined(EPOXY_CORE_ESP8266)
+    if (WiFi.status() != WL_CONNECTED) {
+  #else
+    if (!(Network.getDefaultInterface() != NULL && Network.getDefaultInterface()->connected())) {
+  #endif
+
   #if ACE_TIME_NTP_CLOCK_DEBUG >= 1
     SERIAL_PORT_MONITOR.println(
         F("NtpClock::sendRequest(): not connected"));
@@ -93,7 +122,11 @@ void NtpClock::sendRequest() const {
   // TODO: check return value of hostByName() for errors
   // When there is an error, the ntpServerIP seems to become "0.0.0.0".
   IPAddress ntpServerIP;
-  WiFi.hostByName(mServer, ntpServerIP);
+  #if defined(ESP8266) || defined(EPOXY_CORE_ESP8266)
+    WiFi.hostByName(mServer, ntpServerIP);
+  #else
+    Network.hostByName(mServer, ntpServerIP);
+  #endif
   sendNtpPacket(ntpServerIP);
 }
 
@@ -103,7 +136,11 @@ bool NtpClock::isResponseReady() const {
 #endif
 
   if (!mIsSetUp) return false;
-  if (WiFi.status() != WL_CONNECTED) {
+  #if defined(ESP8266) || defined(EPOXY_CORE_ESP8266)
+    if (WiFi.status() != WL_CONNECTED) {
+  #else
+    if (!(Network.getDefaultInterface() != NULL && Network.getDefaultInterface()->connected())) {
+  #endif
   #if ACE_TIME_NTP_CLOCK_DEBUG >= 3
     if (++rateLimiter == 0) {
       SERIAL_PORT_MONITOR.print("F[256]");
@@ -122,7 +159,11 @@ bool NtpClock::isResponseReady() const {
 
 acetime_t NtpClock::readResponse() const {
   if (!mIsSetUp) return kInvalidSeconds;
-  if (WiFi.status() != WL_CONNECTED) {
+  #if defined(ESP8266) || defined(EPOXY_CORE_ESP8266)
+    if (WiFi.status() != WL_CONNECTED) {
+  #else
+    if (!(Network.getDefaultInterface() != NULL && Network.getDefaultInterface()->connected())) {
+  #endif
   #if ACE_TIME_NTP_CLOCK_DEBUG >= 2
     SERIAL_PORT_MONITOR.println("NtpClock::readResponse(): not connected");
   #endif

--- a/src/ace_time/clock/NtpClock.cpp
+++ b/src/ace_time/clock/NtpClock.cpp
@@ -50,7 +50,7 @@ void NtpClock::setup(
     SERIAL_PORT_MONITOR.print(F("NtpClock::setup(): connected to "));
     SERIAL_PORT_MONITOR.println(WiFi.localIP());
   #else
-  if(Network.getDefaultInterface()){
+  if(Network.getDefaultInterface() && Network.getDefaultInterface()->connected()){
     SERIAL_PORT_MONITOR.print(F("NtpClock::setup(): connected to "));
     SERIAL_PORT_MONITOR.println(Network.getDefaultInterface()->localIP());
   #endif

--- a/src/ace_time/clock/NtpClock.h
+++ b/src/ace_time/clock/NtpClock.h
@@ -11,10 +11,11 @@
 #include <stdint.h>
 #if defined(ESP8266) || defined(EPOXY_CORE_ESP8266)
   #include <ESP8266WiFi.h>
+  #include <WiFiUdp.h>
 #else
+  #include <NetworkManager.h>
   #include <WiFi.h>
 #endif
-#include <WiFiUdp.h>
 #include "Clock.h"
 
 #ifndef ACE_TIME_NTP_CLOCK_DEBUG
@@ -25,9 +26,9 @@ namespace ace_time {
 namespace clock {
 
 /**
- * A Clock that retrieves the time from an NTP server. This class has the
- * deficiency that the DNS name resolver WiFi.hostByName() is a blocking call.
- * So every now and then, it can take 5-6 seconds for the call to return,
+ * A Clock that retrieves the time from an NTP server. This class has the deficiency
+ * that the DNS name resolver <NetworkInterface>.hostByName() is a blocking call.
+ * So every now and then, it can take 5-6 seconds for the call to return, 
  * blocking everything (e.g. display refresh, button clicks) until it times out.
  *
  * NTP seconds is an unsigned 32-bit integer offset from the NTP epoch of
@@ -98,8 +99,8 @@ class NtpClock: public Clock {
 
     /**
      * Set up the WiFi connection using the given ssid and password, and
-     * prepare the UDP connection. If the WiFi connection was set up elsewhere,
-     * you can call the method with no arguments to bypass the WiFi setup.
+     * prepare the UDP connection. If the WiFi/Ethernet connection was set up
+     * elsewhere, you can call the method with no arguments to bypass the WiFi setup.
      *
      * @param ssid wireless SSID (default nullptr)
      * @param password password of the SSID (default nullptr)
@@ -160,7 +161,11 @@ class NtpClock: public Clock {
     uint16_t const mLocalPort;
     uint16_t const mRequestTimeout;
 
+  #if defined(ESP8266) || defined(EPOXY_CORE_ESP8266)
     mutable WiFiUDP mUdp;
+  #else
+    mutable NetworkUDP mUdp;
+  #endif
     // buffer to hold incoming & outgoing packets
     mutable uint8_t mPacketBuffer[kNtpPacketSize];
     bool mIsSetUp = false;


### PR DESCRIPTION
I replaced the static WiFi interface with NetworkManager enabling support for multiple interfaces. This enables NtpClock to also use Ethernet instead of WiFi on ESP32 based chips.

No breaking changes. All function calls are kept backward compatible.

Edit: Requires Arduino >=3.0.0